### PR TITLE
P4: async DLR-driven fallback escalation (dark by default)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -199,6 +199,12 @@ CLOUD_TASKS_LOCATION = env("CLOUD_TASKS_LOCATION", default="europe-west1")
 CLOUD_TASKS_QUEUE = env("CLOUD_TASKS_QUEUE", default="javi-rating")
 CLOUD_TASKS_SERVICE_URL = env("CLOUD_TASKS_SERVICE_URL", default="https://javi.serbito.rs")
 
+# P4: async-эскалация по delivery-receipt. «Принято провайдером» ≠ «доставлено» — если
+# on_the_way не подтверждён доставкой за FALLBACK_ESCALATION_DELAY_MINUTES, Cloud Task шлёт
+# следующим неиспробованным каналом цепочки. Off by default (как и WhatsApp/Telegram).
+FALLBACK_ESCALATION_ENABLED = env.bool("FALLBACK_ESCALATION_ENABLED", default=False)
+FALLBACK_ESCALATION_DELAY_MINUTES = env.int("FALLBACK_ESCALATION_DELAY_MINUTES", default=10)
+
 # Публичный базовый URL для ссылок в сообщениях (трекинг).
 PUBLIC_BASE_URL = env("PUBLIC_BASE_URL", default="https://javi.serbito.rs")
 

--- a/deliveries/services.py
+++ b/deliveries/services.py
@@ -13,7 +13,13 @@ from django.utils.translation import gettext
 
 from common.phone import PhoneResult
 from common.timewindow import format_eta, rating_send_time
-from integrations.providers import get_maps_provider, get_messaging_provider, get_routes_provider
+from integrations.providers import (
+    chain_channel_paths,
+    get_maps_provider,
+    get_messaging_provider,
+    get_messaging_provider_for,
+    get_routes_provider,
+)
 from notifications.models import Notification, NotificationAttempt
 from notifications.services import is_opted_out
 from tasks.scheduler import get_task_scheduler
@@ -237,6 +243,90 @@ def _send_and_record(notification: Notification, delivery: Delivery, text: str):
     return result
 
 
+# --- P4: async-эскалация по delivery-receipt -------------------------------
+
+
+def _on_the_way_notification(delivery: Delivery) -> Notification | None:
+    return delivery.notifications.filter(kind=Notification.Kind.ON_THE_WAY).first()
+
+
+def _untried_chain_paths(notification: Notification) -> list[str]:
+    """Пути провайдеров цепочки, чьи каналы ещё НЕ пробовали для этого сообщения."""
+    tried = {a.channel for a in notification.attempts.all()}
+    return [path for ch, path in chain_channel_paths() if ch not in tried]
+
+
+def _schedule_escalation_if_pending(delivery: Delivery, notification: Notification) -> None:
+    from django.conf import settings
+
+    if not getattr(settings, "FALLBACK_ESCALATION_ENABLED", False):
+        return
+    if not _untried_chain_paths(notification):
+        return  # неиспробованных каналов нет — эскалировать некуда
+    run_at = timezone.now() + timedelta(
+        minutes=getattr(settings, "FALLBACK_ESCALATION_DELAY_MINUTES", 10)
+    )
+    try:
+        get_task_scheduler().schedule_escalation(delivery.id, run_at)
+    except Exception:
+        logger.exception("failed to schedule escalation for delivery %s", delivery.id)
+
+
+def _append_attempts(notification: Notification, result) -> None:
+    """Дописывает попытки эскалации к существующим (НЕ затирает — продолжение того же
+    логического сообщения), продолжая нумерацию attempt_no."""
+    attempts = getattr(result, "attempts", ()) or ()
+    if not attempts:
+        attempts = (_AttemptView(result.channel, result.ok, result.provider_message_id),)
+    start_no = max((a.attempt_no for a in notification.attempts.all()), default=0)
+    NotificationAttempt.objects.bulk_create(
+        [
+            NotificationAttempt(
+                notification=notification,
+                channel=a.channel or "",
+                ok=bool(a.ok),
+                provider_message_id=a.provider_message_id or "",
+                attempt_no=start_no + i + 1,
+            )
+            for i, a in enumerate(attempts)
+        ]
+    )
+
+
+def escalate_delivery(delivery: Delivery) -> bool:
+    """Если on_the_way НЕ подтверждён доставкой — отправить следующим неиспробованным каналом
+    цепочки. No-op при выключенном флаге, уже доставленном сообщении или исчерпанных каналах.
+    Возвращает True, если эскалация ушла (принята провайдером)."""
+    from django.conf import settings
+
+    if not getattr(settings, "FALLBACK_ESCALATION_ENABLED", False):
+        return False
+    notification = _on_the_way_notification(delivery)
+    if notification is None:
+        return False
+    if notification.status in (Notification.Status.DELIVERED, Notification.Status.READ):
+        return False  # доставлено/прочитано — эскалация не нужна
+    paths = _untried_chain_paths(notification)
+    token = getattr(delivery, "tracking_token", None)
+    if not paths or token is None:
+        return False  # каналы исчерпаны или нет токена трекинга
+
+    text = _on_the_way_text(delivery, token.token)
+    result = get_messaging_provider_for(paths).send_text(delivery.recipient_phone, text)
+    _append_attempts(notification, result)
+
+    if result.ok:
+        # Победитель эскалации становится «текущим» каналом/id (для будущих receipts).
+        notification.channel = result.channel
+        notification.provider_message_id = result.provider_message_id or ""
+        notification.status = Notification.Status.SENT
+        notification.sent_at = timezone.now()
+        notification.save(update_fields=["channel", "provider_message_id", "status", "sent_at"])
+        # Остались ещё неиспробованные каналы → планируем следующую проверку.
+        _schedule_escalation_if_pending(delivery, notification)
+    return result.ok
+
+
 def start_delivery(delivery: Delivery, *, manual_eta: datetime | None = None) -> StartResult:
     """«Доставка началась»: рассчитать ETA, уведомить получателя. Идемпотентно.
 
@@ -285,6 +375,10 @@ def start_delivery(delivery: Delivery, *, manual_eta: datetime | None = None) ->
         get_task_scheduler().schedule_rating_request(delivery.id, rating_send_time(eta_at))
     except Exception:
         logger.exception("failed to schedule rating request for delivery %s", delivery.id)
+
+    # P4: если включена эскалатция и остались неиспробованные каналы — запланировать проверку
+    # доставки. Сбой планировщика не ломает старт (сообщение уже ушло).
+    _schedule_escalation_if_pending(delivery, notification)
 
     # Исходящий вебхук мерчанту (декуплено, безопасно — notify_merchant сам глушит сбои).
     emit_delivery_event(delivery, "delivery.started")

--- a/docs/planning-artifacts/multichannel-fallback-plan.md
+++ b/docs/planning-artifacts/multichannel-fallback-plan.md
@@ -198,4 +198,16 @@ once P0/P1 land), merged sequentially — mind shared files (`providers.py`, `me
 - **External onboarding needed before turning channels on** (code is dark/flagged): WhatsApp =
   Meta business verification + approved Utility template + `WHATSAPP_SENDER`; Telegram = create
   bot, set webhook with secret, users opt in via shared-contact button.
-- **Next:** P4 (async DLR-driven escalation) — optional, later.
+- **P4 done** (dark by default): async DLR-driven escalation. After `start_delivery` accepts a
+  send on channel N, schedules a Cloud Task (reuses the `javi-rating` queue) at
+  `now + FALLBACK_ESCALATION_DELAY_MINUTES`. The `/tasks/escalate/<id>/` callback (secret-
+  guarded) runs `escalate_delivery`: if the on_the_way notification is DELIVERED/READ → no-op;
+  else it sends via the next **untried** chain channel (`get_messaging_provider_for(untried)`),
+  appends `NotificationAttempt` rows (continuing attempt_no), updates the winning channel/id on
+  the Notification, and re-schedules if channels remain. Gated by `FALLBACK_ESCALATION_ENABLED`
+  (default False) + `FALLBACK_ESCALATION_DELAY_MINUTES` (default 10). No model/migration change.
+  Note: escalation fires on *non-delivery within the timeout* (send-accepted ≠ delivered); the
+  webhook FAILED path is covered by the same timeout check (not wired as a separate immediate
+  trigger — possible future refinement). **Full suite 234 green, ruff clean.**
+- **All phases P0–P4 complete.** Live in prod: P0/P1 (v0.40.0), P2/P3 + API parity (v0.41.0),
+  all behind flags. WhatsApp/Telegram/escalation stay dark until flags + external onboarding.

--- a/integrations/providers.py
+++ b/integrations/providers.py
@@ -54,6 +54,25 @@ def _default_chain_paths() -> list[str]:
     return chain
 
 
+def _chain_paths() -> list[str]:
+    """Пути провайдеров настроенной цепочки (MESSAGING_CHAIN или дефолт Viber→SMS)."""
+    return getattr(settings, "MESSAGING_CHAIN", None) or _default_chain_paths()
+
+
+def chain_channel_paths() -> list[tuple[str, str]]:
+    """[(channel, dotted_path), …] для цепочки. channel — класс-атрибут провайдера,
+    читаем без инстанцирования (P4: вычислить следующий неиспробованный канал)."""
+    return [(import_string(p).channel, p) for p in _chain_paths()]
+
+
+def get_messaging_provider_for(paths: list[str]) -> MessagingProvider:
+    """Messaging-цепочка из заданного подмножества путей (P4-эскалация), с метерингом."""
+    provider = ChainedMessagingProvider([import_string(p)() for p in paths])
+    if _metering_on():
+        provider = MeteringMessagingProvider(provider)
+    return provider
+
+
 def _build_messaging_chain() -> MessagingProvider:
     """Собирает MessagingProvider из настроек.
 

--- a/integrations/testing.py
+++ b/integrations/testing.py
@@ -82,3 +82,12 @@ class FakeSmsOkProvider(MessagingProvider):
 
     def send_text(self, to_e164: str, text: str) -> SendResult:
         return SendResult(ok=True, provider_message_id="sms-ok-1", channel="sms")
+
+
+class FakeViberOkProvider(MessagingProvider):
+    """Одно-канальный фейк для цепочки: Viber успешно (принят, но не обязательно доставлен)."""
+
+    channel = "viber"
+
+    def send_text(self, to_e164: str, text: str) -> SendResult:
+        return SendResult(ok=True, provider_message_id="viber-ok-1", channel="viber")

--- a/tasks/scheduler.py
+++ b/tasks/scheduler.py
@@ -27,6 +27,11 @@ class TaskScheduler(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
+        """P4: запланировать проверку доставки на run_at (если не доставлено — следующий канал)."""
+        raise NotImplementedError
+
 
 class NoopTaskScheduler(TaskScheduler):
     """Локальный/дефолтный планировщик: ничего не ставит, только логирует."""
@@ -37,11 +42,15 @@ class NoopTaskScheduler(TaskScheduler):
     def schedule_webhook(self, url: str, body: bytes, headers: dict[str, str]) -> None:
         logger.info("Noop schedule webhook to %s (%d bytes)", url, len(body))
 
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
+        logger.info("Noop schedule escalation for delivery %s at %s", delivery_id, run_at)
+
 
 class CloudTasksScheduler(TaskScheduler):
     """Cloud Tasks: HTTP-задача POST на колбэк с scheduleTime (lazy-import библиотеки)."""
 
-    def schedule_rating_request(self, delivery_id: int, run_at: datetime) -> None:
+    def _schedule_post(self, path: str, run_at: datetime) -> None:
+        """Создать Cloud Tasks HTTP POST-задачу на наш колбэк `path` с scheduleTime."""
         from google.cloud import tasks_v2  # lazy: нужна только в проде
         from google.protobuf import timestamp_pb2
 
@@ -52,8 +61,8 @@ class CloudTasksScheduler(TaskScheduler):
             settings.CLOUD_TASKS_QUEUE,
         )
         url = (
-            f"{settings.CLOUD_TASKS_SERVICE_URL.rstrip('/')}"
-            f"/tasks/send-rating/{delivery_id}/?secret={settings.TASKS_SECRET}"
+            f"{settings.CLOUD_TASKS_SERVICE_URL.rstrip('/')}{path}"
+            f"?secret={settings.TASKS_SECRET}"
         )
         ts = timestamp_pb2.Timestamp()
         ts.FromDatetime(run_at)
@@ -61,15 +70,19 @@ class CloudTasksScheduler(TaskScheduler):
             request={
                 "parent": parent,
                 "task": {
-                    "http_request": {
-                        "http_method": tasks_v2.HttpMethod.POST,
-                        "url": url,
-                    },
+                    "http_request": {"http_method": tasks_v2.HttpMethod.POST, "url": url},
                     "schedule_time": ts,
                 },
             }
         )
+
+    def schedule_rating_request(self, delivery_id: int, run_at: datetime) -> None:
+        self._schedule_post(f"/tasks/send-rating/{delivery_id}/", run_at)
         logger.info("Scheduled rating for delivery %s at %s", delivery_id, run_at)
+
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
+        self._schedule_post(f"/tasks/escalate/{delivery_id}/", run_at)
+        logger.info("Scheduled escalation for delivery %s at %s", delivery_id, run_at)
 
     def schedule_webhook(self, url: str, body: bytes, headers: dict[str, str]) -> None:
         from google.cloud import tasks_v2  # lazy: нужна только в проде

--- a/tasks/testing.py
+++ b/tasks/testing.py
@@ -9,6 +9,7 @@ from .scheduler import TaskScheduler
 
 class RecordingTaskScheduler(TaskScheduler):
     scheduled: list[tuple[int, datetime]] = []
+    escalations: list[tuple[int, datetime]] = []
 
     def schedule_rating_request(self, delivery_id: int, run_at: datetime) -> None:
         type(self).scheduled.append((delivery_id, run_at))
@@ -17,6 +18,9 @@ class RecordingTaskScheduler(TaskScheduler):
         RecordingWebhookScheduler.webhooks.append(
             {"url": url, "body": body, "headers": headers}
         )
+
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
+        type(self).escalations.append((delivery_id, run_at))
 
 
 class RecordingWebhookScheduler(TaskScheduler):
@@ -30,6 +34,9 @@ class RecordingWebhookScheduler(TaskScheduler):
     def schedule_webhook(self, url: str, body: bytes, headers: dict[str, str]) -> None:
         type(self).webhooks.append({"url": url, "body": body, "headers": headers})
 
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
+        RecordingTaskScheduler.escalations.append((delivery_id, run_at))
+
 
 class FailingTaskScheduler(TaskScheduler):
     """Имитирует сбой постановки задачи (напр. недоступность Cloud Tasks)."""
@@ -38,4 +45,7 @@ class FailingTaskScheduler(TaskScheduler):
         raise RuntimeError("cloud tasks unavailable")
 
     def schedule_webhook(self, url: str, body: bytes, headers: dict[str, str]) -> None:
+        raise RuntimeError("cloud tasks unavailable")
+
+    def schedule_escalation(self, delivery_id: int, run_at: datetime) -> None:
         raise RuntimeError("cloud tasks unavailable")

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -83,3 +83,79 @@ def test_send_rating_wrong_secret_forbidden(client):
     delivery = _delivery(shop)
     resp = client.post(f"/tasks/send-rating/{delivery.id}/?secret=wrong")
     assert resp.status_code == 403
+
+
+# --- P4: async DLR-driven escalation (off by default) ---
+
+from deliveries.services import escalate_delivery  # noqa: E402
+
+P4_CHAIN = [
+    "integrations.testing.FakeViberOkProvider",
+    "integrations.testing.FakeSmsOkProvider",
+]
+_P4 = dict(
+    ROUTES_PROVIDER=ROUTES_OK,
+    MESSAGING_PROVIDER="",
+    MESSAGING_CHAIN=P4_CHAIN,
+    TASK_SCHEDULER=SCHED,
+    FALLBACK_ESCALATION_ENABLED=True,
+)
+
+
+@override_settings(**_P4)
+def test_start_schedules_escalation_when_untried_channels_remain():
+    """Viber принят, SMS не пробован → планируется проверка доставки (эскалация)."""
+    RecordingTaskScheduler.escalations = []
+    delivery = _delivery(_make_shop())
+    start_delivery(delivery)
+    assert [d for d, _ in RecordingTaskScheduler.escalations] == [delivery.id]
+
+
+@override_settings(**{**_P4, "FALLBACK_ESCALATION_ENABLED": False})
+def test_start_no_escalation_when_flag_off():
+    RecordingTaskScheduler.escalations = []
+    start_delivery(_delivery(_make_shop()))
+    assert RecordingTaskScheduler.escalations == []
+
+
+@override_settings(**_P4)
+def test_escalate_sends_next_channel_when_not_delivered():
+    """on_the_way не доставлен → следующий канал (SMS): новая попытка, канал обновлён."""
+    RecordingTaskScheduler.escalations = []
+    delivery = _delivery(_make_shop())
+    start_delivery(delivery)
+    notif = delivery.notifications.get(kind=Notification.Kind.ON_THE_WAY)
+    assert notif.channel == "viber"
+
+    assert escalate_delivery(delivery) is True
+    notif.refresh_from_db()
+    assert notif.channel == "sms"
+    assert [(a.attempt_no, a.channel) for a in notif.attempts.all()] == [(1, "viber"), (2, "sms")]
+
+
+@override_settings(**_P4)
+def test_escalate_noop_when_delivered():
+    delivery = _delivery(_make_shop())
+    start_delivery(delivery)
+    notif = delivery.notifications.get(kind=Notification.Kind.ON_THE_WAY)
+    notif.status = Notification.Status.DELIVERED
+    notif.save(update_fields=["status"])
+
+    assert escalate_delivery(delivery) is False
+    assert notif.attempts.count() == 1  # никаких новых попыток
+
+
+@override_settings(**_P4)
+def test_escalate_noop_when_channels_exhausted():
+    delivery = _delivery(_make_shop())
+    start_delivery(delivery)
+    assert escalate_delivery(delivery) is True   # → SMS
+    assert escalate_delivery(delivery) is False  # каналы исчерпаны
+
+
+@override_settings(MESSAGING_PROVIDER="", MESSAGING_CHAIN=P4_CHAIN, TASKS_SECRET=SECRET,
+                   FALLBACK_ESCALATION_ENABLED=True)
+def test_escalate_callback_secret_guarded(client):
+    delivery = _delivery(_make_shop())
+    assert client.post(f"/tasks/escalate/{delivery.id}/?secret=wrong").status_code == 403
+    assert client.post(f"/tasks/escalate/{delivery.id}/?secret={SECRET}").status_code == 200

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import send_rating
+from .views import escalate, send_rating
 
 app_name = "tasks"
 
 urlpatterns = [
     path("send-rating/<int:delivery_id>/", send_rating, name="send_rating"),
+    path("escalate/<int:delivery_id>/", escalate, name="escalate"),
 ]

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -6,15 +6,30 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 
 from deliveries.models import Delivery
-from deliveries.services import send_rating_request
+from deliveries.services import escalate_delivery, send_rating_request
+
+
+def _secret_ok(request) -> bool:
+    secret = request.GET.get("secret") or request.headers.get("X-Tasks-Secret", "")
+    return bool(settings.TASKS_SECRET) and secret == settings.TASKS_SECRET
 
 
 @csrf_exempt
 def send_rating(request, delivery_id):
     """POST от Cloud Tasks по ETA+30 → запрос оценки. Защита — общий секрет (fail-closed)."""
-    secret = request.GET.get("secret") or request.headers.get("X-Tasks-Secret", "")
-    if not settings.TASKS_SECRET or secret != settings.TASKS_SECRET:
+    if not _secret_ok(request):
         return HttpResponseForbidden("forbidden")
     delivery = get_object_or_404(Delivery, pk=delivery_id)
     send_rating_request(delivery)  # идемпотентно
+    return HttpResponse(status=200)
+
+
+@csrf_exempt
+def escalate(request, delivery_id):
+    """P4: POST от Cloud Tasks через FALLBACK_ESCALATION_DELAY_MINUTES. Если on_the_way не
+    подтверждён доставкой — шлём следующим каналом цепочки. Защита — общий секрет."""
+    if not _secret_ok(request):
+        return HttpResponseForbidden("forbidden")
+    delivery = get_object_or_404(Delivery, pk=delivery_id)
+    escalate_delivery(delivery)  # no-op, если уже доставлено / каналы исчерпаны / флаг off
     return HttpResponse(status=200)


### PR DESCRIPTION
Final phase of the multi-channel fallback. **Off by default** — no prod behavior change.

## Why
The synchronous chain only knows a send was **accepted** by the provider, not **delivered**
(delivery/read receipts arrive later via webhook). P4 closes that gap: if a message isn't
confirmed delivered within a timeout, escalate to the next channel.

## How
- After `start_delivery` accepts a send on channel N, schedule a Cloud Task (reuses the
  existing `javi-rating` queue) at `now + FALLBACK_ESCALATION_DELAY_MINUTES`, **only if**
  untried channels remain and `FALLBACK_ESCALATION_ENABLED`.
- The secret-guarded `POST /tasks/escalate/<id>/` callback runs `escalate_delivery`:
  - on_the_way notification already `DELIVERED`/`READ` → **no-op**;
  - otherwise send via the **next untried** chain channel (`get_messaging_provider_for`),
    append `NotificationAttempt` rows (continuing `attempt_no`), move the winning
    channel/`provider_message_id` onto the `Notification`, and **re-schedule** if channels
    remain (so it walks telegram→viber→whatsapp→sms over successive timeouts).
- Idempotent / safe: no-op when the flag is off, when delivered, or when channels are exhausted.

## Surface
- settings: `FALLBACK_ESCALATION_ENABLED` (False), `FALLBACK_ESCALATION_DELAY_MINUTES` (10).
- scheduler: `schedule_escalation` across ABC / Noop / CloudTasks (shared `_schedule_post`) +
  test fakes.
- providers: `chain_channel_paths()` (reads each provider's class-level `channel`) +
  `get_messaging_provider_for(paths)`.
- tasks: `escalate` view + route. **No model/migration change.**

## Tests
+6 (scheduling on/off, escalate sends next channel, no-op when delivered / exhausted, callback
secret-guard). **Full suite 234 green, ruff clean.**

Completes **P0–P4**. Plan: `docs/planning-artifacts/multichannel-fallback-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)